### PR TITLE
removed aws env variables and hcp env variables

### DIFF
--- a/datacenter-deploy-ecs-hcp-existing/modules.tf
+++ b/datacenter-deploy-ecs-hcp-existing/modules.tf
@@ -61,6 +61,7 @@ module "example_client_app" {
   acls                           = true
   consul_client_token_secret_arn = module.acl_controller.client_token_secret_arn
   acl_secret_name_prefix         = var.name
+  consul_datacenter              = var.consul_datacenter
 }
 
 module "example_server_app" {
@@ -88,4 +89,5 @@ module "example_server_app" {
   acls                           = true
   consul_client_token_secret_arn = module.acl_controller.client_token_secret_arn
   acl_secret_name_prefix         = var.name
+  consul_datacenter              = var.consul_datacenter
 }

--- a/datacenter-deploy-ecs-hcp/README.md
+++ b/datacenter-deploy-ecs-hcp/README.md
@@ -56,8 +56,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_hcp_client_id"></a> [hcp\_client\_id](#input\_hcp\_client\_id) | HCP Client ID. | `string` | n/a | yes |
-| <a name="input_hcp_client_secret"></a> [hcp\_client\_secret](#input\_hcp\_client\_secret) | HCP Client Secret. | `string` | n/a | yes |
 | <a name="input_lb_ingress_ip"></a> [lb\_ingress\_ip](#input\_lb\_ingress\_ip) | Your Public IP. This is used in the load balancer security groups to ensure only you can access the Consul UI and example application. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier. | `string` | `"consul-ecs"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `"us-east-1"` | no |

--- a/datacenter-deploy-ecs-hcp/providers.tf
+++ b/datacenter-deploy-ecs-hcp/providers.tf
@@ -13,11 +13,6 @@ terraform {
 
 provider "aws" {
   region = var.region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
 }
 
-provider "hcp" {
-  client_id     = var.hcp_client_id
-  client_secret = var.hcp_client_secret
-}
+provider "hcp" {}

--- a/datacenter-deploy-ecs-hcp/terraform.tfvars.example
+++ b/datacenter-deploy-ecs-hcp/terraform.tfvars.example
@@ -1,7 +1,3 @@
 lb_ingress_ip = "YOUR_PUBLIC_IP"
-hcp_client_id = "YOUR_HCP_CLIENT_ID"
-hcp_client_secret = "YOUR_HCP_CLIENT_SECRET"
 aws_region     = "us-east-1"
-aws_access_key = "YOUR_AWS_ACCESS_KEY"
-aws_secret_key = "YOUR_AWS_SECRET_KEY"
 name = "learn-hcp"

--- a/datacenter-deploy-ecs-hcp/variables.tf
+++ b/datacenter-deploy-ecs-hcp/variables.tf
@@ -10,31 +10,8 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable "aws_access_key" {
-  description = "AWS access key."
-  type        = string
-  default     = null
-}
-
-variable "aws_secret_key" {
-  description = "AWS secret key."
-  type        = string
-  default     = null
-}
-
 variable "lb_ingress_ip" {
   description = "Your Public IP. This is used in the load balancer security groups to ensure only you can access the Consul UI and example application."
-  type        = string
-}
-
-
-variable "hcp_client_id" {
-  description = "HCP Client ID."
-  type        = string
-}
-
-variable "hcp_client_secret" {
-  description = "HCP Client Secret."
   type        = string
 }
 


### PR DESCRIPTION
This PR removes aws and hcp credentials variables. This also fixed the missing consul datacenter variable for existing HCP terraform logic