### PR TITLE
Update HCP Consul tier to development

### DIFF
--- a/datacenter-deploy-hcp-eks-lambda/modules/infra/variables.tf
+++ b/datacenter-deploy-hcp-eks-lambda/modules/infra/variables.tf
@@ -42,7 +42,7 @@ variable "hvn_id" {
 variable "consul_tier" {
   type        = string
   description = "The HCP Consul tier to use when creating a Consul cluster"
-  default     = "standard"
+  default     = "development"
 }
 
 variable "consul_version" {


### PR DESCRIPTION
This PR updates the HCP Consul tier to development. I don't see why this has to be `standard` since it's for demo/tutorial purposes only